### PR TITLE
Fix Sonatype Nexus Publishing Validation & Add Support for JDK 1.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,10 @@ java {
     withSourcesJar()
 }
 
+kotlin {
+    jvmToolchain(8)
+}
+
 gradlePlugin {
     plugins {
         create("OcTemplateGradlePlugin") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,13 @@ tasks.named<GroovyCompile>("compileGroovy") {
     classpath += files(tasks.named<KotlinCompile>("compileKotlin").get().destinationDirectory)
 }
 
+java {
+    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    withJavadocJar()
+    withSourcesJar()
+}
+
 gradlePlugin {
     plugins {
         create("OcTemplateGradlePlugin") {
@@ -102,7 +109,7 @@ nexusPublishing {
 
 publishing {
     publications {
-        create<MavenPublication>("maven") {
+        withType<MavenPublication> {
             pom {
                 name.set(project.name)
                 description.set(project.description)
@@ -134,7 +141,7 @@ signing {
     val signingKey: String? by project
     val signingPassword: String? by project
     useInMemoryPgpKeys(signingKey, signingPassword)
-    sign(publishing.publications["maven"])
+    sign(publishing.publications)
 }
 
 project.tasks.findByPath("publish")?.dependsOn(":artifactoryPublish")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 import java.time.Duration
 
 plugins {
@@ -32,16 +34,14 @@ tasks.named<GroovyCompile>("compileGroovy") {
     classpath += files(tasks.named<KotlinCompile>("compileKotlin").get().destinationDirectory)
 }
 
-java {
-    targetCompatibility = JavaVersion.VERSION_1_8
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    withJavadocJar()
-    withSourcesJar()
+tasks.withType<KotlinJvmCompile>().configureEach {
+    compilerOptions {
+        suppressWarnings = true
+        jvmTarget = JvmTarget.JVM_1_8
+    }
 }
 
-kotlin {
-    jvmToolchain(8)
-}
+java.targetCompatibility = JavaVersion.VERSION_1_8
 
 gradlePlugin {
     plugins {


### PR DESCRIPTION
- Fix publishing validation:
  - Missing project name, project description, project URL, license information, SCM URL, developer information 
  - Missing javadoc and sources jar
  - Missing signature
- Set Java and Kotlin compatibility to Java 8 (JVM 1.8)