### PR TITLE
Fix Sonatype Nexus Publishing Validation: Add Sources & Javadoc Jar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,11 @@ tasks.withType<KotlinJvmCompile>().configureEach {
     }
 }
 
-java.targetCompatibility = JavaVersion.VERSION_1_8
+java {
+    withSourcesJar()
+    withJavadocJar()
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 gradlePlugin {
     plugins {


### PR DESCRIPTION
Fix publishing validation: **missing javadoc and sources jar**