### PR TITLE
Add auto cleanup option to control automatic resource deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ ocTemplate {
     // Optional pods readiness settings
     period.set(1200L)  // Delay (ms) between readiness checks, default: 15000L
     attempts.set(20)   // Max number of check attempts, default: 20
+    
+    autoCleanup.set(true)  // Auto cleanup of created resources, default: true
 
     // Register services
     service("database") {

--- a/src/main/groovy/org/octopusden/octopus/oc/template/plugins/gradle/OcTaskConfiguration.groovy
+++ b/src/main/groovy/org/octopusden/octopus/oc/template/plugins/gradle/OcTaskConfiguration.groovy
@@ -59,7 +59,8 @@ class OcTaskConfiguration {
                     project.objects.mapProperty(String, String).value(getDefaultParameters() + serviceSetting.parameters.get()),
                     ocTemplateSettings.workDir,
                     ocTemplateSettings.period,
-                    ocTemplateSettings.attempts
+                    ocTemplateSettings.attempts,
+                    ocTemplateSettings.autoCleanup
                 )) as Provider<OcTemplateService>
             serviceDependencyGraph.add(serviceName, serviceSetting.dependsOn.get())
         }

--- a/src/main/groovy/org/octopusden/octopus/oc/template/plugins/gradle/OcTemplateSetting.groovy
+++ b/src/main/groovy/org/octopusden/octopus/oc/template/plugins/gradle/OcTemplateSetting.groovy
@@ -8,7 +8,6 @@ import org.gradle.api.Task
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.TaskProvider
-import java.util.zip.CRC32
 
 @CompileStatic
 abstract class OcTemplateSetting {
@@ -30,6 +29,7 @@ abstract class OcTemplateSetting {
 
     abstract Property<Long> getPeriod()
     abstract Property<Integer> getAttempts()
+    abstract Property<Boolean> getAutoCleanup()
 
     private String nestedName
 
@@ -48,6 +48,7 @@ abstract class OcTemplateSetting {
 
         period.set(DEFAULT_WAIT_PERIOD)
         attempts.set(DEFAULT_WAIT_ATTEMPTS)
+        autoCleanup.set(true)
 
         applyEnvVariableOverrides()
 

--- a/src/main/kotlin/org/octopusden/octopus/oc/template/plugins/gradle/service/OcTemplateService.kt
+++ b/src/main/kotlin/org/octopusden/octopus/oc/template/plugins/gradle/service/OcTemplateService.kt
@@ -28,6 +28,7 @@ abstract class OcTemplateService @Inject constructor(
         val workDir: DirectoryProperty
         val period: Property<Long>
         val attempts: Property<Int>
+        val autoCleanup: Property<Boolean>
     }
 
     private val serviceName = parameters.serviceName.get()
@@ -156,7 +157,11 @@ abstract class OcTemplateService @Inject constructor(
     }
 
     override fun close() {
-        delete()
+        if (parameters.autoCleanup.getOrElse(true)) {
+            delete()
+        } else {
+            logger.info("Skipping cleanup of created resources (autoCleanup=false)")
+        }
     }
 
 }

--- a/src/main/kotlin/org/octopusden/octopus/oc/template/plugins/gradle/service/OcTemplateServiceRegistry.kt
+++ b/src/main/kotlin/org/octopusden/octopus/oc/template/plugins/gradle/service/OcTemplateServiceRegistry.kt
@@ -31,6 +31,7 @@ open class OcTemplateServiceRegistry @Inject constructor (
                     templateParameters.set(config.templateParameters)
                     attempts.set(config.attempts)
                     period.set(config.period)
+                    autoCleanup.set(config.autoCleanup)
                 }
             }
         }

--- a/src/main/kotlin/org/octopusden/octopus/oc/template/plugins/gradle/service/dto/OcTemplateServiceParametersDTO.kt
+++ b/src/main/kotlin/org/octopusden/octopus/oc/template/plugins/gradle/service/dto/OcTemplateServiceParametersDTO.kt
@@ -14,5 +14,6 @@ data class OcTemplateServiceParametersDTO(
     override val templateParameters: MapProperty<String, String>,
     override val workDir: DirectoryProperty,
     override val period: Property<Long>,
-    override val attempts: Property<Int>
+    override val attempts: Property<Int>,
+    override val autoCleanup: Property<Boolean>,
 ): OcTemplateService.Parameters


### PR DESCRIPTION
By default, the plugin deletes all resources created from templates after the build. This update adds an `autoCleanup` option to control that behavior—useful for projects that deploy resources to OKD without needing automatic cleanup.